### PR TITLE
Issue #12 forced posix handling of CDN paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function joinBaseAndPath(base, urlPath) {
   if (urlPath[0] === '/')
     rest = rest.split('/')[0];
   // Join it all together
-  return protocol + '//' + path.normalize("" + rest + "/" + urlPath);
+  return protocol + '//' + path.posix.normalize("" + rest + "/" + urlPath);
 }
 
 // Default options


### PR DESCRIPTION
On Windows, using `path.normalize` produced backslashes `\` instead of forward slashes `/` in asset URLs. This fixes issue #12.
